### PR TITLE
Create CocoaPods spec file for the project.

### DIFF
--- a/Demos/Sample/Podfile
+++ b/Demos/Sample/Podfile
@@ -1,0 +1,5 @@
+source 'https://github.com/CocoaPods/Specs.git'
+platform :ios, '8.0'
+
+pod 'crosswalk-ios', :path => "../../"
+

--- a/crosswalk-ios.podspec
+++ b/crosswalk-ios.podspec
@@ -1,0 +1,25 @@
+# Copyright (c) 2015 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+Pod::Spec.new do |s|
+  s.name             = 'crosswalk-ios'
+  s.version          = '0.5.0'
+  s.summary          = 'Crosswalk for iOS is aimming to provide a web runtime to develop sophisticated iOS native or hybrid applications.'
+  s.homepage         = 'https://github.com/crosswalk-project/crosswalk-ios'
+  s.license          = { :type => 'BSD', :file => "LICENSE" }
+  s.author           = { 'Zhenyu Liang' => 'zhenyu.liang@intel.com', 'Jonathan Dong' => 'jonathan.dong@intel.com' }
+  s.source           = { :git => 'https://github.com/crosswalk-project/crosswalk-ios.git', :tag => s.version.to_s }
+  s.social_media_url = 'https://twitter.com/xwalk_project'
+
+  s.platform = :ios, '8.0'
+  s.ios.deployment_target = '8.0'
+  s.requires_arc = true
+  s.module_name = 'XWalkView'
+
+  s.source_files = 'XWalkView/XWalkView/*.{h,m,swift}'
+  s.resource = 'XWalkView/XWalkView/crosswalk.js'
+  s.private_header_files = 'XWalkView/XWalkView/XWalkHttpConnection.h'
+
+end
+


### PR DESCRIPTION
NOTICE:
1. Because CocoaPods just support Swift and framework recently,
please use `sudo gem install cocoapods --pre` to install the
prereleased version to try.
2. We haven't upload the podspec, will do this after legal review
and the CocoaPods' framework feature gets ready.
2. Demos/Sample/Podfile is a way to verify the usability of the
crosswalk-ios pod, and we haven't convert the project file to adapt
to the CocoaPods way, will do it asa podspec get upload.
