### PR TITLE
Fix of a bug in bind() method of XWalkChannel

### DIFF
--- a/XWalkView/XWalkView/XWalkChannel.swift
+++ b/XWalkView/XWalkView/XWalkChannel.swift
@@ -26,12 +26,9 @@ public class XWalkChannel : NSObject, WKScriptMessageHandler {
         webView.configuration.userContentController.addScriptMessageHandler(self, name: "\(self.name)")
     }
 
-    public func bind(object: AnyObject, namespace: String, thread: NSThread? = nil) {
+    public func bind(object: AnyObject, namespace: String, thread: NSThread) {
         self.namespace = namespace
-        self.thread = thread ?? webView.extensionThread
-        if self.thread is XWalkThread && !self.thread.executing {
-            self.thread.start()
-        }
+        self.thread = thread
 
         mirror = XWalkReflection(cls: object.dynamicType)
         var script = XWalkStubGenerator(reflection: mirror).generate(name, namespace: namespace, object: object)

--- a/XWalkView/XWalkView/XWalkWebView.swift
+++ b/XWalkView/XWalkView/XWalkWebView.swift
@@ -28,8 +28,11 @@ public extension WKWebView {
     }
 
     public func loadExtension(object: AnyObject, namespace: String, thread: NSThread? = nil) {
+        if !extensionThread.executing && thread == nil {
+            extensionThread.start()
+        }
         let channel = XWalkChannel(webView: self)
-        channel.bind(object, namespace: namespace, thread: thread)
+        channel.bind(object, namespace: namespace, thread: thread ?? extensionThread)
     }
 
     internal func injectScript(code: String) -> WKUserScript {


### PR DESCRIPTION
crosswalk.js is injected only when the thread argument is nil.
