### PR TITLE
XWalkChannel test cases.

### DIFF
--- a/XWalkView/XWalkViewTests/XWalkChannelTest.swift
+++ b/XWalkView/XWalkViewTests/XWalkChannelTest.swift
@@ -3,25 +3,95 @@
 // found in the LICENSE file.
 
 import UIKit
+import WebKit
 import XCTest
+import XWalkView
 
-class XWalkChannelTest: XCTestCase {
+class ExecutionContext {
+    var scriptToEvaluate: String
+    let completionHandler: ((AnyObject!, NSError!) -> Void)?
+
+    init(script: String, completionHandler:((AnyObject!, NSError!) -> Void)?) {
+        self.scriptToEvaluate = script
+        self.completionHandler = completionHandler
+    }
+}
+
+class ChannelTestExtension: XWalkExtension {
+    var expectation: XCTestExpectation? = nil
+
+    override func didBindExtension(channel: XWalkChannel!, instance: Int) {
+        expectation?.fulfill()
+    }
+}
+
+class XWalkChannelTest: XCTestCase, WKNavigationDelegate {
+    var webview: WKWebView? = nil
+    var channel: XWalkChannel? = nil
+
+    var executionContext: ExecutionContext? = nil
+
+    private let extensionName = "xwalk.test.channel"
 
     override func setUp() {
         super.setUp()
+        webview = WKWebView(frame: CGRectZero, configuration: WKWebViewConfiguration())
+        webview?.navigationDelegate = self
+
+        XWalkExtensionFactory.register(extensionName, cls: ChannelTestExtension.self)
+        channel = XWalkChannel(webView: webview!)
+
+        var ext = XWalkExtensionFactory.createExtension(extensionName) as ChannelTestExtension
+        channel?.bind(ext, namespace: extensionName)
     }
 
     override func tearDown() {
         super.tearDown()
+        webview = nil
+        channel = nil
+    }
+
+    func webView(webView: WKWebView, didCommitNavigation navigation: WKNavigation!) {
+        if let context = self.executionContext {
+            self.channel?.evaluateJavaScript(context.scriptToEvaluate, completionHandler: {(object, error) in
+                if let handler = context.completionHandler {
+                    handler(object, error)
+                }
+            })
+        }
     }
 
     func testBind() {
-        XCTAssert(true, "Pass")
+        var ext = XWalkExtensionFactory.createExtension(extensionName) as ChannelTestExtension
+        ext.expectation = self.expectationWithDescription("testBindExpectation")
+        channel?.bind(ext, namespace: extensionName)
+
+        self.waitForExpectationsWithTimeout(0.1, handler:{ (error) in
+            if let e = error {
+                XCTFail("testBind Failed")
+            }
+        })
     }
 
     func testEvaluateJavaScript() {
-        XCTAssert(true, "Pass")
-    }
+        var expectation = self.expectationWithDescription("ExpectationEvaluateJavaScript")
+        var executionContext = ExecutionContext(script: "typeof(\(extensionName));", completionHandler:{ (object, error) in
+            if error != nil {
+                println("Failed to evaluate javascript, error:\(error)")
+            } else {
+                expectation.fulfill()
+            }
+        })
 
+        self.executionContext = executionContext
+
+        webview?.loadHTMLString("<html></html>", baseURL: nil)
+
+        self.waitForExpectationsWithTimeout(1, handler: { (error) in
+            if let e = error {
+                XCTFail("testEvaluateJavaScript failed, with error:\(e)")
+            }
+        })
+    }
 }
 


### PR DESCRIPTION
As addUserScript() take times, if we'd like to access the javascript
objects injected with the addUserScript(), we have to wait untill the
document loading completed, or in didCommitNavigation() as early as
possible.
