### PR TITLE
Insert user defined js codes into extension object

### DIFF
--- a/XWalkView/XWalkView/XWalkExtension.m
+++ b/XWalkView/XWalkView/XWalkExtension.m
@@ -58,16 +58,25 @@
 
 - (NSString*)didGenerateStub:(NSString*)stub {
     NSBundle* bundle = [NSBundle bundleForClass:self.class];
-    NSString* name = NSStringFromClass(self.class);
-    if (name.pathExtension.length) {
-        name = name.pathExtension;
+    NSString* className = NSStringFromClass(self.class);
+    if (className.pathExtension.length) {
+        className = className.pathExtension;
     }
-    NSString* path = [bundle pathForResource:name ofType:@"js"];
-    if (path) {
-        NSString* content = [NSString stringWithContentsOfFile:path encoding:NSUTF8StringEncoding error:nil];
+
+    NSString* fileToReplace = [NSString stringWithFormat:@"%@-replace", className];
+    NSString* replacePath = [bundle pathForResource:fileToReplace ofType:@"js"];
+    NSString* fileToAppend = [NSString stringWithFormat:@"%@-append", className];
+    NSString* appendPath = [bundle pathForResource:fileToAppend ofType:@"js"];
+    if (replacePath) {
+        NSString* content = [NSString stringWithContentsOfFile:replacePath encoding:NSUTF8StringEncoding error:nil];
+        if (content)
+            return content;
+    } else if (appendPath) {
+        NSString* content = [NSString stringWithContentsOfFile:appendPath encoding:NSUTF8StringEncoding error:nil];
         if (content)
             return [stub stringByAppendingString:content];
     }
+
     return stub;
 }
 

--- a/XWalkView/XWalkView/XWalkReflection.swift
+++ b/XWalkView/XWalkView/XWalkReflection.swift
@@ -30,7 +30,7 @@ import Foundation
         var setter: Method = nil
     }
 
-    private let cls: AnyClass
+    public let cls: AnyClass
     private var members: [String: MemberInfo] = [:]
     private var ctor: Method = nil
 

--- a/XWalkView/XWalkView/XWalkStubGenerator.swift
+++ b/XWalkView/XWalkView/XWalkStubGenerator.swift
@@ -30,6 +30,9 @@ class XWalkStubGenerator {
                 stub += "Extension.defineProperty(exports, '\(name)', \(value), \(!mirror.isReadonly(name)));\n"
             }
         }
+        if let script = userDefinedJavaScript() {
+            stub += script
+        }
         stub += "\n})(Extension.create(\(channelName), '\(namespace)'"
         if mirror.constructor != nil {
             stub += ", " + generateMethodStub("+", selector: mirror.constructor) + ", true"
@@ -64,6 +67,24 @@ class XWalkStubGenerator {
             body = "\(this).\(body)]);"
         }
         return "function(\(list)) {\n    \(body)\n}"
+    }
+
+    private func userDefinedJavaScript() -> String? {
+        var className = NSStringFromClass(self.mirror.cls)
+        if (className == nil) {
+            return nil
+        }
+
+        if count(className.pathExtension) > 0 {
+            className = className.pathExtension
+        }
+        var bundle = NSBundle(forClass: self.mirror.cls)
+        if let path = bundle.pathForResource(className, ofType: "js") {
+            if let content = String(contentsOfFile: path, encoding: NSUTF8StringEncoding, error: nil) {
+                return content
+            }
+        }
+        return nil
     }
 }
 


### PR DESCRIPTION
Before this patch we've appended the user defined javascript codes
after the auto generated stub codes, but it seems more convenient
that we insert this part of codes into the extension object
function.
