### PR TITLE
Use derived XWalkView instead of WKWebView extension.

### DIFF
--- a/AppShell/AppShell/ViewController.swift
+++ b/AppShell/AppShell/ViewController.swift
@@ -19,7 +19,7 @@ class ViewController: UIViewController {
             }
         }
 
-        let webview = WKWebView(frame: view.frame, configuration: WKWebViewConfiguration())
+        let webview = XWalkView(frame: view.frame, configuration: WKWebViewConfiguration())
         webview.scrollView.bounces = false
         view.addSubview(webview)
 

--- a/XWalkView/XWalkView/XWalkExtensionLoader.swift
+++ b/XWalkView/XWalkView/XWalkExtensionLoader.swift
@@ -10,7 +10,7 @@ class XWalkExtensionLoader: XWalkExtension {
         let initializer: Selector = argument == nil ? "init" : "initWithJSValue:"
         let arguments: [AnyObject] = argument == nil ? [] : [argument!]
         if let ext: AnyObject = XWalkExtensionFactory.createExtension(name, initializer: initializer, arguments: arguments) {
-            channel.webView.loadExtension(ext, namespace: namespace ?? name)
+            channel.webView?.loadExtension(ext, namespace: namespace ?? name)
             // TODO: Call success callback with the extension object
             invokeCallback(_Promise, key:"resolve", arguments: nil)
         } else {

--- a/XWalkView/XWalkViewTests/XWalkChannelTest.swift
+++ b/XWalkView/XWalkViewTests/XWalkChannelTest.swift
@@ -17,7 +17,7 @@ class ChannelTestExtension: XWalkExtension {
 }
 
 class XWalkChannelTest: XCTestCase, WKNavigationDelegate {
-    var webview: WKWebView? = nil
+    var webview: XWalkView? = nil
     var channel: XWalkChannel? = nil
 
     var executionContext: ExecutionContext? = nil
@@ -26,14 +26,14 @@ class XWalkChannelTest: XCTestCase, WKNavigationDelegate {
 
     override func setUp() {
         super.setUp()
-        webview = WKWebView(frame: CGRectZero, configuration: WKWebViewConfiguration())
+        webview = XWalkView(frame: CGRectZero, configuration: WKWebViewConfiguration())
         webview?.navigationDelegate = self
 
         XWalkExtensionFactory.register(extensionName, cls: ChannelTestExtension.self)
         channel = XWalkChannel(webView: webview!)
 
         var ext = XWalkExtensionFactory.createExtension(extensionName) as! ChannelTestExtension
-        channel?.bind(ext, namespace: extensionName, thread: webview!.extensionThread)
+        channel?.bind(ext, namespace: extensionName, thread: nil)
     }
 
     override func tearDown() {
@@ -55,7 +55,7 @@ class XWalkChannelTest: XCTestCase, WKNavigationDelegate {
     func testBind() {
         var ext = XWalkExtensionFactory.createExtension(extensionName) as! ChannelTestExtension
         ext.expectation = self.expectationWithDescription("testBindExpectation")
-        channel?.bind(ext, namespace: extensionName, thread: webview!.extensionThread)
+        channel?.bind(ext, namespace: extensionName, thread: nil)
 
         self.waitForExpectationsWithTimeout(0.1, handler:{ (error) in
             if let e = error {

--- a/XWalkView/XWalkViewTests/XWalkExtensionTest.m
+++ b/XWalkView/XWalkViewTests/XWalkExtensionTest.m
@@ -61,7 +61,7 @@
 
 @interface XWalkExtensionTest : XCTestCase <WKNavigationDelegate>
 
-@property(nonatomic, strong) WKWebView* webview;
+@property(nonatomic, strong) XWalkView* webview;
 @property(nonatomic, copy) NSString* extensionName;
 @property(nonatomic, strong) ExecutionContext* executionContext;
 @property(nonatomic, strong) ExtensionTestExtension* ext;
@@ -73,13 +73,13 @@
 - (void)setUp {
     [super setUp];
     self.extensionName = @"xwalk.test.ext";
-    self.webview = [[WKWebView alloc] initWithFrame:CGRectZero configuration:[[WKWebViewConfiguration alloc] init]];
+    self.webview = [[XWalkView alloc] initWithFrame:CGRectZero configuration:[[WKWebViewConfiguration alloc] init]];
     self.webview.navigationDelegate = self;
 
     [XWalkExtensionFactory register:self.extensionName cls:[ExtensionTestExtension class]];
 
     self.ext = (ExtensionTestExtension*)[XWalkExtensionFactory createExtension:self.extensionName];
-    [self.webview loadExtension:self.ext namespace:self.extensionName thread:nil];
+    [self.webview loadExtension:self.ext namespace:self.extensionName];
 }
 
 - (void)tearDown {
@@ -138,7 +138,7 @@
 - (void)testDidGenerateStub {
     ExtensionTestExtension* ext = (ExtensionTestExtension*)[XWalkExtensionFactory createExtension:self.extensionName];
     ext.didGenerateStubExpectation = [self expectationWithDescription:@"DidGenerateStubExtension"];
-    [self.webview loadExtension:ext namespace:self.extensionName thread:nil];
+    [self.webview loadExtension:ext namespace:self.extensionName];
 
     [self waitForExpectationsWithTimeout:1 handler:^(NSError *error) {
         if (error) {
@@ -150,7 +150,7 @@
 - (void)testDidBindExtension {
     ExtensionTestExtension* ext = (ExtensionTestExtension*)[XWalkExtensionFactory createExtension:self.extensionName];
     ext.didBindExpectation = [self expectationWithDescription:@"DidBindExtension"];
-    [self.webview loadExtension:ext namespace:self.extensionName thread:nil];
+    [self.webview loadExtension:ext namespace:self.extensionName];
 
     [self waitForExpectationsWithTimeout:1 handler:^(NSError *error) {
         if (error) {

--- a/XWalkView/XWalkViewTests/XWalkWebViewTests.swift
+++ b/XWalkView/XWalkViewTests/XWalkWebViewTests.swift
@@ -11,23 +11,16 @@ class WebViewExtension: XWalkExtension {
 }
 
 class XWalkWebViewTests: XCTestCase {
-    var webview: WKWebView? = nil
+    var webview: XWalkView? = nil
 
     override func setUp() {
         super.setUp()
-        webview = WKWebView(frame: CGRectZero, configuration: WKWebViewConfiguration())
+        webview = XWalkView(frame: CGRectZero, configuration: WKWebViewConfiguration())
     }
 
     override func tearDown() {
         super.tearDown()
         webview = nil
-    }
-
-    func testExtensionThread() {
-        XCTAssertNotNil(webview?.extensionThread, "Failed to retrive extensionThread")
-        var thread: NSThread = NSThread()
-        webview!.extensionThread = thread
-        XCTAssertEqual(thread, webview!.extensionThread)
     }
 
     func testLoadExtension() {


### PR DESCRIPTION
Because the associated object's deinit time is not as expected,
we decide to choose derived XWalkView instead of WKWebView extension.
XWalkView will hold the channels and manage the life cycle of them;
Channel will weak reference the thread object, and the loadExtension
interface won't need to ask user about the threading.

Testcases are upgraded accordingly.
