### PR TITLE
Fixed the extension property observing issue

### DIFF
--- a/XWalkView/XWalkView/XWalkWebView.swift
+++ b/XWalkView/XWalkView/XWalkWebView.swift
@@ -10,8 +10,8 @@ public class XWalkView : WKWebView {
     private var channels: Dictionary<String, XWalkChannel> = [:]
 
     deinit {
-        for name in channels.keys {
-            self.configuration.userContentController.removeScriptMessageHandlerForName(name)
+        for channel in channels.values {
+            channel.destroyExtension()
         }
     }
 

--- a/XWalkView/XWalkViewTests/XWalkChannelTest.swift
+++ b/XWalkView/XWalkViewTests/XWalkChannelTest.swift
@@ -33,13 +33,14 @@ class XWalkChannelTest: XCTestCase, WKNavigationDelegate {
         channel = XWalkChannel(webView: webview!)
 
         var ext = XWalkExtensionFactory.createExtension(extensionName) as! ChannelTestExtension
+        webview?.loadExtension(ext, namespace: extensionName)
         channel?.bind(ext, namespace: extensionName, thread: nil)
     }
 
     override func tearDown() {
         super.tearDown()
-        webview = nil
         channel = nil
+        webview = nil
     }
 
     func webView(webView: WKWebView, didCommitNavigation navigation: WKNavigation!) {
@@ -68,7 +69,7 @@ class XWalkChannelTest: XCTestCase, WKNavigationDelegate {
         var expectation = self.expectationWithDescription("ExpectationEvaluateJavaScript")
         var executionContext = ExecutionContext(script: "typeof(\(extensionName));", completionHandler:{ (object, error) in
             if error != nil {
-                println("Failed to evaluate javascript, error:\(error)")
+                XCTFail("Failed to evaluate javascript, error:\(error)")
             } else {
                 expectation.fulfill()
             }


### PR DESCRIPTION
We need to explicitly call the didUnbindExtension when destructing
channels, which will remove the observers which watching the
extension properties. Or the observers could not be created again
after the webview get destructed.
