### PR TITLE
Fixed the issue that Cordova demos cannot build

### DIFF
--- a/AppShell/AppShell/CordovaViewController.swift
+++ b/AppShell/AppShell/CordovaViewController.swift
@@ -20,7 +20,7 @@ class ViewController: CDVViewController {
             }
         }
 
-        let webview = WKWebView(frame: view.frame, configuration: WKWebViewConfiguration())
+        let webview = XWalkView(frame: view.frame, configuration: WKWebViewConfiguration())
         webview.navigationDelegate = self
         webview.scrollView.bounces = false
         view.addSubview(webview)


### PR DESCRIPTION
Replace the WKWebView with XWalkView, due to the recent change of
the implementation.

BUG: https://crosswalk-project.org/jira/browse/XWALK-4476
