### PR TITLE
Changed bundle load for configuration to be XWalk specific.

### DIFF
--- a/XWalkView/XWalkView/XWalkWebView.m
+++ b/XWalkView/XWalkView/XWalkWebView.m
@@ -56,7 +56,7 @@
 
 - (void)prepareForExtension
 {
-    NSBundle* bundle = [NSBundle bundleForClass:self.class];
+    NSBundle* bundle = [NSBundle bundleForClass:XWalkView.class];
     NSAssert(bundle, @"Failed to load bundle for class:", self.description);
     if (!bundle) {
         return;


### PR DESCRIPTION
- Using self.class for the bundle lookup breaks when the class in the
  library is subclassed outside of the library.
